### PR TITLE
Locks debug to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.3",
   "license": "MIT",
   "dependencies": {
-    "debug": "*"
+    "debug": "2.2.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Recent changes to `debug` has introduced some breaking changes in their new `4.x` branch. For upstream consumers of `component-cookie`, these breaking changes have made their way into builds, especially those using older versions of node/npm etc.

This PR addresses this issue and locks the debug version to `2.2.0` similarly to the `component.json` change made in https://github.com/component/cookie/commit/91cb08336d248ccddc7aeed5058d6fe3059870e9

