### PR TITLE
Require debug ^2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.4",
   "license": "MIT",
   "dependencies": {
-    "debug": "2.2.0"
+    "debug": "^3.2.4"
   },
   "devDependencies": {
     "mocha": "*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.4",
   "license": "MIT",
   "dependencies": {
-    "debug": "^3.2.4"
+    "debug": "^2.6.9"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
There is a minor security vulnerability in the module `debug`: https://nodesecurity.io/advisories/534

This was resolved in debug@2.6.9 and 3.1.0.

Debug introduced let/const in v3.2.0, breaking compatibility with node.js v4 and older browsers. This was reverted in 3.2.4, then re-released it in 4.0.0 - see https://github.com/visionmedia/debug/issues/603 for context around that.

In order avoid the vulnerability without loosing any compatibility, this change locks component-cookie to ~`^3.2.4` (>= 3.2.4 and < 4.0.0).~ (Update: now `^2.6.9`)

This Fixes #16, relates to #15, and is is part of the fix for https://github.com/matthewmueller/next-cookies/issues/7