### PR TITLE
fix handling of = in cookie values

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,10 +98,18 @@ function parse(str) {
   var obj = {};
   var pairs = str.split(/ *; */);
   var pair;
-  if ('' == pairs[0]) return obj;
+  var eqidx;
+  var name;
+  var value;
   for (var i = 0; i < pairs.length; ++i) {
-    pair = pairs[i].split('=');
-    obj[decode(pair[0])] = decode(pair[1]);
+    pair = pairs[i];
+    eqidx = pair.indexOf("=");
+    if (eqidx === -1) {
+      eqidx = pair.length;
+    }
+    name = decode(pair.substr(0, eqidx));
+    value = decode(pair.substr(eqidx + 1)); // +1 because we don't want the =
+    obj[name] = value;
   }
   return obj;
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -75,4 +75,13 @@ describe('cookie()', function(){
     assert('ferret' == obj.species, '.species failed');
     assert(null == obj.bad);
   });
+
+  it('should properly handle equal signs in the value', function(){
+    // see https://github.com/matthewmueller/next-cookies/issues/20
+    var values = ['=', '==', '===', 'a=b', 'a==b', 'a=', 'SEnxqTgooNWEFfQ9gUipwdhUrZm1VejMLDQ=='];
+    values.forEach(function(value) {
+      document.cookie = 'name=' + value;
+      assert.equal(value, cookie('name'));
+    });
+  });
 })


### PR DESCRIPTION
If there is any `=` in the cookie's value, component-cookie would loose both the `=` and everything after it. This PR fixes that.

See also: https://github.com/matthewmueller/next-cookies/issues/20

Additionally, I couldn't get the tests to run out-of-the box. I did some tweaks to fix that, but I'll put them into a separate PR.

Fixes #8 (when the cookie is set by the server rather than this library)